### PR TITLE
HOTFIX: Fixed healthcheck error in db container.

### DIFF
--- a/compose.deploy.yaml
+++ b/compose.deploy.yaml
@@ -31,9 +31,8 @@ services:
   db:
     image: postgres:17
     restart: always
-    env_file: 
-      - .env
     volumes:
+      - db-data-test:/var/lib/postgresql/data
       - ./backend/db/01-init.sql:/docker-entrypoint-initdb.d/01-init.sql
       - ./backend/db/02-default_seed.sql:/docker-entrypoint-initdb.d/02-default_seed.sql
     environment:
@@ -41,7 +40,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_USER=${POSTGRES_USER}
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -42,9 +42,8 @@ services:
   db:
     image: postgres:17
     restart: always
-    env_file: 
-      - .env
     volumes:
+      - db-data-test:/var/lib/postgresql/data
       - ./backend/db/01-init.sql:/docker-entrypoint-initdb.d/01-init.sql
       - ./backend/db/02-default_seed.sql:/docker-entrypoint-initdb.d/02-default_seed.sql
       - ./backend/db/03-development_seed.sql:/docker-entrypoint-initdb.d/03-development_seed.sql
@@ -53,7 +52,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_USER=${POSTGRES_USER}
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
The healthcheck caused FATAL: role 'postgres' does not exist. Used .env variables for healthcheck and added -d flag to define database.